### PR TITLE
:sparkles: feat: CustomButton props 추가 (onClick)

### DIFF
--- a/src/components/CustomButton.tsx
+++ b/src/components/CustomButton.tsx
@@ -5,12 +5,18 @@ interface btnProps {
     size?: 'large' | 'medium' | 'small'
     color?: 'primary' | 'sub' | string
     children?: React.ReactNode
+    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, ...args: any[]) => void
+    onClickArgs?: any[]
 }
-
 interface ColorMap {
     [key: string]: string
 }
-const CustomButton = ({ size = 'medium', color = 'primary', children, ...rest }: btnProps) => {
+const CustomButton = ({ size = 'medium', color = 'primary', children, onClick, onClickArgs, ...rest }: btnProps) => {
+    const clickEvent = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+        if (onClick) {
+            onClick(event, ...(onClickArgs || []))
+        }
+    }
     const colorMap: ColorMap = {
         primary: '#5c940d',
         sub: '#ffffff',
@@ -29,7 +35,7 @@ const CustomButton = ({ size = 'medium', color = 'primary', children, ...rest }:
     const border = '1px solid #5c940d'
 
     return (
-        <Button style={{ width, backgroundColor, borderRadius, color: textColor, border }} {...rest}>
+        <Button style={{ width, backgroundColor, borderRadius, color: textColor, border }} onClick={clickEvent} {...rest}>
             {children}
         </Button>
     )


### PR DESCRIPTION
- CustomButton Props 에 onClick Props를 추가
- 컴포넌트에서 작성한 메소드를 onClick 의 props로 추가하면 클릭할때 해당 메서드가 호출된다.

ex) 
```
<CustomButton size="medium" color="primary" onClick={() => console.log("라조기")}>오늘 야식</CustomButton>
// "라조기"
```