### PR TITLE
✨ feat: Post api, 글쓰기 페이지 UI 및 Event 함수 추가

### DIFF
--- a/src/apis/Post.ts
+++ b/src/apis/Post.ts
@@ -1,0 +1,17 @@
+import { PostRequest, Post } from '@/types/Post'
+import { axiosInstance } from './axios'
+import { instance } from './instance'
+
+export const createPost = async (createPostData: PostRequest) => {
+    const { data } = await axiosInstance.post<Post>('/post', createPostData, {
+        headers: {
+            'Content-Type': 'multipart/form-data',
+        },
+    })
+    console.log(data)
+}
+
+export const getPost = async (id: string) => {
+    const response = await instance.get(`/posts/${id}`)
+    return response.data
+}

--- a/src/pages/post/new.tsx
+++ b/src/pages/post/new.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react'
+import { Box, IconButton, TextField } from '@mui/material'
+import { ArrowBack, PhotoOutlined, VideoFileOutlined, Gif } from '@mui/icons-material'
+import CustomButton from '@/components/CustomButton'
+
+type PostFormProps = {
+    submitHandler: (post: FormData) => void
+    initialValue?: { body: string; img: string }
+}
+
+function CreatePost({ submitHandler, initialValue = { body: '', img: '' } }: PostFormProps) {
+    const mainColor = '#5c940d'
+    const [postInput, setPostInput] = useState(initialValue)
+    const [content, setContent] = useState('')
+    const [previewUrl, setPreviewUrl] = useState('')
+
+    const handleContentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setContent(e.target.value)
+        const content = e.target.value
+        if (content.length <= 150) {
+            setContent(content)
+        }
+    }
+
+    // 다른 확장자 추가를 시도할 시, 미디어가 교체되고 한 개의 미디어만 출력됩니다.
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files && e.target.files[0]
+        if (file) {
+            const reader = new FileReader()
+            reader.onloadend = () => {
+                setPreviewUrl(reader.result as string)
+            }
+            reader.readAsDataURL(file)
+        }
+    }
+
+    const handleClearPreview = () => {
+        setPreviewUrl('')
+        setPostInput((prevState) => ({ ...prevState, img: '' }))
+        // const formData = new FormData()
+        // formData.append('body', content)
+        // if (postInput.img) {
+        //     formData.append('img', postInput.img)
+        // }
+        // submitHandler(formData)
+        // setContent('')
+        // setPreviewUrl('')
+    }
+
+    // 글쓰기에 추가한 내용 모두 저장할 함수
+    const handlePostSubmit = () => {
+        // e.preventDefault();
+        setContent('')
+        setPreviewUrl('')
+        const formData = new FormData()
+        formData.append('body', content)
+        if (postInput.img) {
+            formData.append('img', postInput.img)
+        }
+        // submitHandler(formData)
+        console.log(content, postInput.img, formData)
+        submitHandler(formData)
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <Box id="componentsWrapper" sx={{ width: 'inherit', alignItems: 'center' }}>
+                <Box id="topNavWrapper" sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <IconButton href="/post" aria-label="back" sx={{ color: `${mainColor}` }}>
+                        <ArrowBack />
+                    </IconButton>
+                    <CustomButton onClick={handlePostSubmit} type="submit" size="small" color="primary">
+                        HOOT
+                    </CustomButton>
+                </Box>
+                <TextField
+                    placeholder="글을 작성해 주세요"
+                    value={content}
+                    onChange={handleContentChange}
+                    fullWidth
+                    multiline
+                    rows={6}
+                    variant="standard"
+                    sx={{ margin: '2em 0.5em' }}
+                    color="success"
+                    focused
+                />
+                {previewUrl && (
+                    <Box mb={2}>
+                        <img src={previewUrl} alt="Preview" style={{ maxWidth: '50%', margin: '0 0.5em' }} />
+                        <CustomButton onClick={handleClearPreview} size="small" color="secondary">
+                            지우기
+                        </CustomButton>
+                    </Box>
+                )}
+                <Box display="flex" alignItems="center">
+                    <IconButton component="label" htmlFor="photo-input" sx={{ color: `${mainColor}`, width: '2em' }}>
+                        <PhotoOutlined />
+                        <input type="file" id="photo-input" accept="image/*" hidden onChange={handleFileChange} />
+                    </IconButton>
+                    <IconButton component="label" htmlFor="video-input" sx={{ color: `${mainColor}`, width: '2em' }}>
+                        <VideoFileOutlined />
+                        <input type="file" id="video-input" accept="video/*" hidden onChange={handleFileChange} />
+                    </IconButton>
+                    <IconButton component="label" htmlFor="gif-input" sx={{ color: `${mainColor}`, width: '2em' }}>
+                        <Gif />
+                        <input type="file" id="gif-input" accept="image/*" hidden onChange={handleFileChange} />
+                    </IconButton>
+                </Box>
+            </Box>
+        </div>
+    )
+}
+export default CreatePost


### PR DESCRIPTION
#7 
- [x] UI: 뒤로가기, 저장버튼, 글쓰기, 미디어 추가를 위한 아이콘버튼

#8 
- [x] 텍스트는 150자로 제한한다.
- [x] 좌측 상단에 arrow 버튼 생성, 클릭 시 메인화면으로 이동해야한다

#9 

- [x] 이미지/동영상 추가시 미리보기로 확인 가능하다
- [x]  미디어는 하나만 올릴 수 있다.

## Todos
 - [ ] Hoot버튼을 클릭하면 글쓰기 내용이 저장되어야 한다.
 - [ ] 글이 저장되면 페이지의 내용은 사라지고 메인화면으로 나가져야한다.
 - [ ] 메인화면에 게시글이 추가되어야한다
 - [ ]  multer를 사용한 이미지/동영상이 서버에 추가 되어야 한다
 - [ ] 가운데 정렬 및 반응형 화면대응 리팩토링 필요

### Issue
- submitHandler is not a function 타입에러 리팩토링 필요
 