### PR TITLE
:bug: 루트 경로 접속 시 버그 수정

### DIFF
--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -14,8 +14,12 @@ const withAuth = (Component: NextPage | React.FC) => {
             }
         }, [isAuthenticated])
 
+        // 인증 진행 중 일 때
         if (isAuthenticated !== 'SUCCESS') return <>로딩 중..</>
-        // 로그인이 되어있다면
+        // 인증 완료 & 루트 경로로 접속 시 피드 페이지로 이동
+        if (isAuthenticated === 'SUCCESS' && router.pathname === '/') {
+            router.push('/post')
+        }
         return <Component />
     }
 

--- a/src/utils/verifyToken.ts
+++ b/src/utils/verifyToken.ts
@@ -7,8 +7,9 @@ type AuthType = 'PENDING' | 'SUCCESS' | 'FAILED'
 
 function verifyToken() {
     const [isAuthenticated, setIsAuthenticated] = useState<AuthType>('PENDING')
-    const verifyResult = useQuery(['auth', 'verify'], verify, {
-        enabled: !!getCookie('accessToken'), // 값이 없으면 undefined. 값을 boolean으로 변환
+    const token = getCookie('accessToken')
+    const verifyResult = useQuery(['auth', 'verify', token], verify, {
+        enabled: !!token, // 값이 없으면 undefined. 값을 boolean으로 변환
         // 유효하다면
         onSuccess: () => {
             setIsAuthenticated('SUCCESS')
@@ -22,7 +23,7 @@ function verifyToken() {
 
     // 엑세스 토큰이 없을 때
     const refreshResult = useQuery(['auth', 'refresh'], refresh, {
-        enabled: !getCookie('accessToken'), // 엑세스 토큰이 없을 때에만 refresh 요청 전송
+        enabled: !token, // 엑세스 토큰이 없을 때에만 refresh 요청 전송
         onSuccess: (data) => {
             setCookie('accessToken', data.accessToken, {
                 path: '/',


### PR DESCRIPTION
## 수정 사항
- 기존 버전에서는 루트 경로 접속 시 인증 성공하면 그대로 루트 경로 콘텐츠를 보여줬었습니다. (실질적으로 빈 페이지)
- `ProtectedRouter.tsx`에 분기처리를 통해 해당 케이스를 `/post` 경로로 리다이렉트 되도록 했습니다.

- 추가적으로, 기존 accessToken이 존재하면 query 요청을 실행하지 않는 문제를 query key값을 unique하게 바꿈으로써 정상적으로 verify요청이 날라가도록 수정했습니다. (`verifyToken.ts`)