### PR TITLE
:sparkles: feat: 생성/수정 페이지 구현

### DIFF
--- a/src/apis/Post.ts
+++ b/src/apis/Post.ts
@@ -1,7 +1,7 @@
 import { PostRequest, Post } from '@/types/Post'
 import { axiosInstance } from './axios'
 
-export const createPost = async (createPostData: PostRequest) => {
+export const createPost = async (createPostData: FormData) => {
     const { data } = await axiosInstance.post<Post>('/post', createPostData, {
         headers: {
             'Content-Type': 'multipart/form-data',

--- a/src/components/cards/PostForm.tsx
+++ b/src/components/cards/PostForm.tsx
@@ -1,0 +1,124 @@
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import TextField from '@mui/material/TextField'
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import PhotoOutlined from '@mui/icons-material/PhotoOutlined'
+import VideoFileOutlined from '@mui/icons-material/VideoFileOutlined'
+import Gif from '@mui/icons-material/Gif'
+
+import React, { useState } from 'react'
+import CustomButton from '@/components/CustomButton'
+import { axiosInstance } from '@/apis/axios'
+import withAuth from '@/routes/ProtectedRoute'
+import { useRouter } from 'next/router'
+
+interface PostInput {
+    content: string
+    img: File | null
+}
+interface PostFormProps {
+    mutate: (formData: FormData) => void
+    initialValue?: PostInput
+}
+
+function PostForm({ mutate, initialValue = { content: '', img: null } }: PostFormProps) {
+    const mainColor = '#5c940d'
+    const [postInput, setPostInput] = useState<PostInput>(initialValue)
+    const [previewUrl, setPreviewUrl] = useState('')
+    const router = useRouter()
+    // 미디어 추가 함수
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const { name, value, files } = e.target
+        // console.log('Files:', files)
+        console.log(name, value, files)
+
+        const file = files && files[0]
+        if (files) {
+            setPostInput({ ...postInput, [name]: files[0] })
+        } else {
+            setPostInput({ ...postInput, [name]: value })
+        }
+        // preview condition
+        if (file) {
+            const reader = new FileReader()
+            reader.onloadend = () => {
+                console.log('File read successfully:', reader.result)
+                setPreviewUrl(reader.result as string)
+            }
+            reader.readAsDataURL(file)
+        }
+        console.log('handleChange result:', postInput, file)
+    }
+
+    //미디어 지우기
+    const handleClearPreview = () => {
+        setPreviewUrl('')
+    }
+
+    const handlePostSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+        e.preventDefault()
+        const formData = new FormData()
+
+        formData.append('content', postInput.content)
+        formData.append('file', postInput.img as File)
+        mutate(formData)
+        console.log(formData.getAll('img'))
+        alert('Hedwig가 날아갑니다')
+        router.push('/post')
+        console.log('handlePostSubmit result:')
+    }
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <Box id="componentsWrapper" sx={{ width: 'inherit', alignItems: 'center' }}>
+                <Box id="topNavWrapper" sx={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <IconButton href="/post" aria-label="back" sx={{ color: `${mainColor}` }}>
+                        <ArrowBack />
+                    </IconButton>
+                    <form onSubmit={handlePostSubmit}>
+                        <CustomButton type="submit" size="small" color="primary">
+                            HOOT
+                        </CustomButton>
+                    </form>
+                </Box>
+                <TextField
+                    placeholder="글을 작성해 주세요"
+                    onChange={handleChange}
+                    inputProps={{ name: 'content' }}
+                    fullWidth
+                    multiline
+                    rows={6}
+                    variant="standard"
+                    sx={{ margin: '2em 0.5em' }}
+                    color="success"
+                    focused
+                    defaultValue={initialValue.content}
+                />
+                {previewUrl && (
+                    <Box mb={2}>
+                        <img src={previewUrl} alt="Preview" style={{ maxWidth: '50%', margin: '0 0.5em' }} />
+                        <CustomButton onClick={handleClearPreview} size="small" color="secondary">
+                            지우기
+                        </CustomButton>
+                    </Box>
+                )}
+                <Box display="flex" alignItems="center">
+                    <IconButton component="label" htmlFor="photo-input" sx={{ color: `${mainColor}`, width: '2em' }}>
+                        <PhotoOutlined />
+                        <input name="img" type="file" id="photo-input" accept="image/*" hidden onChange={handleChange} />
+                    </IconButton>
+                    <IconButton component="label" htmlFor="video-input" sx={{ color: `${mainColor}`, width: '2em' }}>
+                        <VideoFileOutlined />
+                        <input name="img" type="file" id="video-input" accept="video/*" hidden onChange={handleChange} />
+                    </IconButton>
+                    <IconButton component="label" htmlFor="gif-input" sx={{ color: `${mainColor}`, width: '2em' }}>
+                        <Gif />
+                        <input name="img" type="file" id="gif-input" accept="image/*" hidden onChange={handleChange} />
+                    </IconButton>
+                </Box>
+            </Box>
+        </div>
+    )
+}
+
+export default PostForm

--- a/src/components/cards/postCard/index.tsx
+++ b/src/components/cards/postCard/index.tsx
@@ -72,12 +72,12 @@ function PostCard({ userName, content, createdAt, updatedAt, id, img, likesCount
             <>
                 <StyledCardContent>{content}</StyledCardContent>
                 <Box>
-                    {img && !isDetailPost ? <StyledCardMedia image={img} /> : <StyledCardMedia image={img} onClick={handleClickOpen} />}
+                    {img && !isDetailPost ? <StyledCardMedia image={img.toString()} /> : <StyledCardMedia image={img?.toString()} onClick={handleClickOpen} />}
 
                     {img && open && (
                         <Dialog open={open} onClose={handleClose}>
                             <DialogContent>
-                                <img src={img} style={{ width: '100%' }} />
+                                <img src={img.toString()} style={{ width: '100%' }} />
                             </DialogContent>
                         </Dialog>
                     )}

--- a/src/pages/post/edit/[id].tsx
+++ b/src/pages/post/edit/[id].tsx
@@ -1,42 +1,39 @@
-import { getPost, getPosts } from '@/apis/Post'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import TextField from '@mui/material/TextField'
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import PhotoOutlined from '@mui/icons-material/PhotoOutlined'
+import VideoFileOutlined from '@mui/icons-material/VideoFileOutlined'
+import Gif from '@mui/icons-material/Gif'
+
+import React, { useEffect, useState } from 'react'
+import CustomButton from '@/components/CustomButton'
 import { axiosInstance } from '@/apis/axios'
-import { Post } from '@/types/Post'
-import { GetStaticPaths, GetStaticProps, GetStaticPropsContext } from 'next'
-import { useRouter } from 'next/router'
-import React from 'react'
-import CommentInput from '@/components/cards/commentInput'
-import PostCard from '@/components/cards/postCard'
 import withAuth from '@/routes/ProtectedRoute'
+import { useRouter } from 'next/router'
+import { useQuery } from 'react-query'
+import { getPost } from '@/apis/Post'
+import PostForm from '@/components/cards/PostForm'
 
-type Props = {
-    post: Post
+interface PostInput {
+    body: string
+    img: File | null
 }
-// export const getStaticPaths: GetStaticPaths = async () => {
-//     const res = await fetch(process.env.customKey + `/post`)
-//     const data = await res.json()
-
-//     const paths = data.map((post: Post) => ({
-//         params: { id: post.id.toString() },
-//     }))
-
-//     return { paths, fallback: false }
-// }
-
-// export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
-//     const id = Number(params?.id)
-//     const res = await fetch(process.env.customKey + `/post/${id}`)
-//     const data = await res.json()
-//     const post = data
-//     return {
-//         props: { post },
-//     }
-// }
 
 const editDetail = () => {
     const router = useRouter()
-    const id = router.query.id
+    const id = Number(router.query.id)
+    const { data: singlePost, isLoading } = useQuery(['post', id], () => getPost(id))
 
-    return <div>{/*<CommentInput profileImg={'/default.png'} userName={post.userName} />*/}</div>
+    // 글쓰기에 추가한 내용 모두 저장 할 함수
+    const mutate = async (formData: FormData) => {
+        await axiosInstance.put(`/post/${id}`, formData)
+    }
+
+    if (isLoading) {
+        return <div>로딩중</div>
+    }
+    return <PostForm mutate={mutate} initialValue={singlePost} />
 }
 
 export default withAuth(editDetail)

--- a/src/pages/post/new.tsx
+++ b/src/pages/post/new.tsx
@@ -1,113 +1,29 @@
-import Box from '@mui/material/Box';
-import IconButton from '@mui/material/IconButton';
-import TextField from '@mui/material/TextField';
-import ArrowBack from '@mui/icons-material/ArrowBack';
-import PhotoOutlined from '@mui/icons-material/PhotoOutlined';
-import VideoFileOutlined from '@mui/icons-material/VideoFileOutlined';
-import Gif from '@mui/icons-material/Gif';
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import TextField from '@mui/material/TextField'
+import ArrowBack from '@mui/icons-material/ArrowBack'
+import PhotoOutlined from '@mui/icons-material/PhotoOutlined'
+import VideoFileOutlined from '@mui/icons-material/VideoFileOutlined'
+import Gif from '@mui/icons-material/Gif'
 
 import React, { useState } from 'react'
 import CustomButton from '@/components/CustomButton'
 import { axiosInstance } from '@/apis/axios'
 import withAuth from '@/routes/ProtectedRoute'
+import { useRouter } from 'next/router'
+import PostForm from '@/components/cards/PostForm'
+import { createPost } from '@/apis/Post'
 interface PostInput {
     body: string
     img: File | null
 }
 
 function CreatePost() {
-    const mainColor = '#5c940d'
-    const [postInput, setPostInput] = useState<PostInput>({ body: '', img: null })
-    const [previewUrl, setPreviewUrl] = useState('')
-
-    // 미디어 추가 함수
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value, files } = e.target
-        console.log('Files:', files)
-
-        const file = files && files[0]
-        if (files) {
-            setPostInput({ ...postInput, [name]: files[0] })
-        } else {
-            setPostInput({ ...postInput, [name]: value })
-        }
-        // preview condition
-        if (file) {
-            const reader = new FileReader()
-            reader.onloadend = () => {
-                console.log('File read successfully:', reader.result)
-                setPreviewUrl(reader.result as string)
-            }
-            reader.readAsDataURL(file)
-        }
-        console.log('handleChange result:', postInput, file)
-    }
-
-    //미디어 지우기
-    const handleClearPreview = () => {
-        setPreviewUrl('')
-    }
-
     // 글쓰기에 추가한 내용 모두 저장 할 함수
-    const handlePostSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-        e.preventDefault()
-        const formData = new FormData()
-        formData.append('body', postInput.body)
-        formData.append('img', postInput.img as File)
-        await axiosInstance.post('/post', formData)
-
-        console.log('handlePostSubmit result:', postInput)
+    const mutate = async (formData: FormData) => {
+        await createPost(formData)
     }
 
-    return (
-        <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <Box id="componentsWrapper" sx={{ width: 'inherit', alignItems: 'center' }}>
-                <Box id="topNavWrapper" sx={{ display: 'flex', justifyContent: 'space-between' }}>
-                    <IconButton href="/post" aria-label="back" sx={{ color: `${mainColor}` }}>
-                        <ArrowBack />
-                    </IconButton>
-                    <form onSubmit={handlePostSubmit}>
-                        <CustomButton type="submit" size="small" color="primary">
-                            HOOT
-                        </CustomButton>
-                    </form>
-                </Box>
-                <TextField
-                    placeholder="글을 작성해 주세요"
-                    onChange={handleChange}
-                    inputProps={{ name: 'body' }}
-                    fullWidth
-                    multiline
-                    rows={6}
-                    variant="standard"
-                    sx={{ margin: '2em 0.5em' }}
-                    color="success"
-                    focused
-                />
-                {previewUrl && (
-                    <Box mb={2}>
-                        <img src={previewUrl} alt="Preview" style={{ maxWidth: '50%', margin: '0 0.5em' }} />
-                        <CustomButton onClick={handleClearPreview} size="small" color="secondary">
-                            지우기
-                        </CustomButton>
-                    </Box>
-                )}
-                <Box display="flex" alignItems="center">
-                    <IconButton component="label" htmlFor="photo-input" sx={{ color: `${mainColor}`, width: '2em' }}>
-                        <PhotoOutlined />
-                        <input name="img" type="file" id="photo-input" accept="image/*" hidden onChange={handleChange} />
-                    </IconButton>
-                    <IconButton component="label" htmlFor="video-input" sx={{ color: `${mainColor}`, width: '2em' }}>
-                        <VideoFileOutlined />
-                        <input name="img" type="file" id="video-input" accept="video/*" hidden onChange={handleChange} />
-                    </IconButton>
-                    <IconButton component="label" htmlFor="gif-input" sx={{ color: `${mainColor}`, width: '2em' }}>
-                        <Gif />
-                        <input name="img" type="file" id="gif-input" accept="image/*" hidden onChange={handleChange} />
-                    </IconButton>
-                </Box>
-            </Box>
-        </div>
-    )
+    return <PostForm mutate={mutate} />
 }
 export default withAuth(CreatePost)

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -3,7 +3,7 @@ import { Comment } from './Comment'
 
 export interface PostRequest {
     content: string
-    img?: string
+    img?: FormData
 }
 
 export interface Post extends PostRequest {


### PR DESCRIPTION
글쓰기 페이지에 있었던 작성 폼 컴포넌트를 분리해서 제작 (PostForm)
- 수정/생성 페이지에 같이 사용할 예정
props 목록 
- mutate : submit 할때 호출되는 react-query (수정/ 생성 에 따라 다른 메소드가 들어감)
- initialValue  : qeury 로 가져온 id값을 파라미터로 하는 getPost(id)로부터 가져온 데이터

- PostRequest 의 타입과 , 게시물 생성을 요청하는 creatPost의 파라미터인 createPostData의 타입을  수정하여 백엔드에서 formData로 인식할수 있게 FormData로 변경함

- PostForm 컴포넌트를 불러와서 외부에서 직접 props를 전달하는 방식으로 변경함

- post 페이지에서 받아오는 컴포넌트의 타입이 FormData이므로 이를 string으로 변경함
